### PR TITLE
update orcid validation schema pattern to include "X" as checksum at …

### DIFF
--- a/datalight/schemas/zenodo/zenodo_upload_metadata_schema.json5
+++ b/datalight/schemas/zenodo/zenodo_upload_metadata_schema.json5
@@ -239,7 +239,7 @@
         },
         "orcid": {
           "type": "string",
-          "pattern": "(\\d{4}-?){3}\\d{4}$"
+          "pattern": "(\\d{4}-?){3}\\d{3}\\w{1}$"
         },
         "gnd": {
           "type": "string"


### PR DESCRIPTION
…end of orcid

### What I did
Updated the zenodo_upload_metadata_schema.json5 validation schema pattern for the orcid to allow for alphanumeric characters to terminate the orcid. 

### Reason
The last 'digit' of any orcid is a checksum, '10' is represented by 'X'. The functions validate_metadata() in zenodo.py and zenodo_metadata.py wouldn't let something like 0000-0002-1694-233X through.

More info [here](https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier)
